### PR TITLE
Add information that >1G ethernet does not work in ACPI boot

### DIFF
--- a/hardware/devices/arm/radxa/orion/orion.md
+++ b/hardware/devices/arm/radxa/orion/orion.md
@@ -27,7 +27,7 @@ Network: 2x 5Gig Ethernet  + M.2 E key (4.0 2x lanes)<br/>
 | eDP          | 🟡 Partial  | Same as above, Confirmed working on a NE140QDM-NX1 panel                                                                              |
 | USB-C DP     | 🟡 Partial  | Same as above                                                                                                                         |
 | Storage      | 🟢 Works    | M.2 SSDs work as expected                                                                                                             |
-| Ethernet     | 🟢 Works    | Random chance of the drivers [crashing](https://forum.radxa.com/t/miscellaneous-testing/26642/13) on boot                             |
+| Ethernet     | 🟡 Partial  | Random chance of the drivers [crashing](https://forum.radxa.com/t/miscellaneous-testing/26642/13) on boot, 2.5/5G mode doesn't work   |
 | Front USB    | 🟢 Works    | Needs [9.0.0 firmware](https://dl.radxa.com/orion/o6/images/bios/SystemReady/latest)                                                  |
 | Rear USB     | 🟢 Works    | Not sure if it's on my end but some ports occasionally disconnect?                                                                    |
 | Front audio  | ⚫ Untested | -                                                                                                                                     |


### PR DESCRIPTION
Autonegotiation to 5G works, but then no data gets through.  The link led of the partner goes off.  5G with the same partner works fine in the official (DTB based) OS image.