### PR TITLE
Add tested hardware to orion docs

### DIFF
--- a/hardware/devices/arm/radxa/orion/orion.md
+++ b/hardware/devices/arm/radxa/orion/orion.md
@@ -70,6 +70,7 @@ Anything with a link is tested by someone other than me, Credits go to them.<br/
 | RX 7800     | 🔴 Broken  | UEFI does not detect the card neither does linux                                                                                                  |
 | RX 7900     | 🟡 Partial | [Detected in linux but causes hang once driver loads](https://github.com/geerlingguy/sbc-reviews/issues/62#issuecomment-2852451205)               |
 | RX 7900 XTX | 🟢 Works   | [Source](https://forum.radxa.com/t/recommended-external-gpu-for-o6/26898/12)                                                                      |
+| RX 9060 XT  | 🟢 Works   | [Source](https://github.com/System64fumo/linux/pull/28)                                                                                           |
 | WX 3100     | 🟢 Works   | [Source](https://x.com/intlinux/status/1884081756556628325)                                                                                       |
 | **Nvidia**  | 🟢 Works   | Works in linux & UEFI when X86EmulatorDxe is available in EDK2 (tested by @HeyMeco)                                                               |
 | GT 210      | 🟢 Works   |                                                                                                                                                   |
@@ -77,6 +78,7 @@ Anything with a link is tested by someone other than me, Credits go to them.<br/
 | GTX 1650    | 🟢 Works   |                                                                                                                                                   |
 | GTX 1660 TI | 🟢 Works   | Tested by [kossLAN](https://github.com/kossLAN)                                                                                                   |
 | RTX 3060    | 🟢 Works   | [Source](https://github.com/geerlingguy/sbc-reviews/issues/62#issuecomment-2799534109)                                                            |
+| RTX 3070    | 🟢 Works   | [Source](https://github.com/System64fumo/linux/pull/28)                                                                                           |
 | RTX 3070 TI | 🟢 Works   | [Source](https://forum.radxa.com/t/recommended-external-gpu-for-o6/26898/8)                                                                       |
 | RTX 3080 TI | 🟡 Partial | [Source](https://github.com/geerlingguy/sbc-reviews/issues/62#issuecomment-2852490521)                                                            |
 | RTX 3090    | 🟢 Works   | [Source](https://x.com/mecoscorner/status/1910018752176857284)                                                                                    |
@@ -85,6 +87,13 @@ Anything with a link is tested by someone other than me, Credits go to them.<br/
 | RTX A400    | 🔴 Broken  | [Source](https://github.com/geerlingguy/sbc-reviews/issues/62#issuecomment-2836546822)                                                            |
 | **Intel**   | 🟡 Partial | Works but sometimes requires hard reset. Driver also needs patch                                                                                  |
 | B580        | 🟡 Partial | Works in linux [Source](https://github.com/System64fumo/linux/pull/7#issuecomment-3068051539)                                                     |
+
+# Network cards
+
+| Device      | Status     | Notes                                                                                                                                             |
+| ------------| -----------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Intel**   | 🟢 Works   | Some cards might need ASPM turned off                                                                                                             |
+| 8265NGW     | 🟡 Partial | Works but needs ASPM turned off [Source](https://github.com/System64fumo/linux/pull/28)                                                                 |
 
 # Storage controllers
 There are multiple options to extend the storage beyond the M.2 E key. One of the options is to use a SAS based raid controller with support for HBA mode.  


### PR DESCRIPTION
Adding in the RTX 3070 and RX 9060 XT as i have ran both successfully on the Orion O6 with no changes to UEFI settings.

Also added in an Intel wifi card that i put in there (mostly for bluetooth) which causes a kernel panic with ASPM turned on in the UEFI, I didnt test all the options available for ASPM, i just turned it off completely which solved the issue well enough for me.


## RX 9060 XT
```
$ sudo dmesg | grep amdgpu
[    2.100520] amdgpu: IO link not available for non x86 platforms
[    2.100528] amdgpu: Virtual CRAT table created for CPU
[    2.100547] amdgpu: Topology: Add CPU node
[    2.100740] amdgpu 0000:c3:00.0: initializing kernel modesetting (IP DISCOVERY 0x1002:0x7590 0x1DA2:0xA493 0xC0).
[    2.100755] amdgpu 0000:c3:00.0: register mmio base: 0x60000000
[    2.100757] amdgpu 0000:c3:00.0: register mmio size: 524288
[    2.105131] amdgpu 0000:c3:00.0: detected ip block number 0 <common_v1_0_0> (soc24_common)
[    2.105136] amdgpu 0000:c3:00.0: detected ip block number 1 <gmc_v12_0_0> (gmc_v12_0)
[    2.105139] amdgpu 0000:c3:00.0: detected ip block number 2 <ih_v7_0_0> (ih_v7_0)
[    2.105141] amdgpu 0000:c3:00.0: detected ip block number 3 <psp_v14_0_0> (psp)
[    2.105144] amdgpu 0000:c3:00.0: detected ip block number 4 <smu_v14_0_0> (smu)
[    2.105145] amdgpu 0000:c3:00.0: detected ip block number 5 <dce_v1_0_0> (dm)
[    2.105147] amdgpu 0000:c3:00.0: detected ip block number 6 <gfx_v12_0_0> (gfx_v12_0)
[    2.105149] amdgpu 0000:c3:00.0: detected ip block number 7 <sdma_v7_0_0> (sdma_v7_0)
[    2.105151] amdgpu 0000:c3:00.0: detected ip block number 8 <vcn_v5_0_0> (vcn_v5_0_0)
[    2.105153] amdgpu 0000:c3:00.0: detected ip block number 9 <jpeg_v5_0_0> (jpeg_v5_0_0)
[    2.105154] amdgpu 0000:c3:00.0: detected ip block number 10 <mes_v12_0_0> (mes_v12_0)
[    2.105177] amdgpu 0000:c3:00.0: Fetched VBIOS from VFCT
[    2.105180] amdgpu 0000:c3:00.0: [drm] ATOM BIOS: 113-P816G493-S06
[    2.252331] amdgpu 0000:c3:00.0: Trusted Memory Zone (TMZ) feature not supported
[    2.252419] amdgpu 0000:c3:00.0: vm size is 262144 GB, 4 levels, block size is 9-bit, fragment size is 9-bit
[    2.252449] amdgpu 0000:c3:00.0: BAR 0 [mem 0x1800000000-0x180fffffff 64bit pref]: releasing
[    2.252453] amdgpu 0000:c3:00.0: BAR 2 [mem 0x1810000000-0x18101fffff 64bit pref]: releasing
[    2.252494] amdgpu 0000:c3:00.0: BAR 0 [mem size 0x400000000 64bit pref]: can't assign; no space
[    2.252495] amdgpu 0000:c3:00.0: BAR 0 [mem size 0x400000000 64bit pref]: failed to assign
[    2.252497] amdgpu 0000:c3:00.0: BAR 2 [mem size 0x00200000 64bit pref]: can't assign; no space
[    2.252498] amdgpu 0000:c3:00.0: BAR 2 [mem size 0x00200000 64bit pref]: failed to assign
[    2.252499] amdgpu 0000:c3:00.0: BAR 0 [mem size 0x400000000 64bit pref]: can't assign; no space
[    2.252500] amdgpu 0000:c3:00.0: BAR 0 [mem size 0x400000000 64bit pref]: failed to assign
[    2.252502] amdgpu 0000:c3:00.0: BAR 2 [mem size 0x00200000 64bit pref]: can't assign; no space
[    2.252503] amdgpu 0000:c3:00.0: BAR 2 [mem size 0x00200000 64bit pref]: failed to assign
[    2.252546] amdgpu 0000:c3:00.0: BAR 2 [mem 0x1810000000-0x18101fffff 64bit pref]: old value restored
[    2.252553] amdgpu 0000:c3:00.0: BAR 0 [mem 0x1800000000-0x180fffffff 64bit pref]: old value restored
[    2.252555] amdgpu 0000:c3:00.0: Not enough PCI address space for a large BAR.
[    2.252558] amdgpu 0000:c3:00.0: VRAM: 16304M 0x0000008000000000 - 0x00000083FAFFFFFF (16304M used)
[    2.252561] amdgpu 0000:c3:00.0: GART: 512M 0x0000000000000000 - 0x000000001FFFFFFF
[    2.252564] amdgpu 0000:c3:00.0: [drm] Detected VRAM RAM=16304M, BAR=256M
[    2.252566] amdgpu 0000:c3:00.0: [drm] RAM width 128bits GDDR6
[    2.252859] amdgpu 0000:c3:00.0:  16304M of VRAM memory ready
[    2.252864] amdgpu 0000:c3:00.0:  15903M of GTT memory ready.
[    2.252898] amdgpu 0000:c3:00.0: [drm] GART: num cpu pages 131072, num gpu pages 131072
[    2.252990] amdgpu 0000:c3:00.0: [drm] PCIE GART of 512M enabled (table at 0x0000008000000000).
[    2.254056] amdgpu 0000:c3:00.0: [drm] Loading DMUB firmware via PSP: version=0x0A000800
[    2.254547] amdgpu 0000:c3:00.0: [VCN instance 0] Found VCN firmware Version ENC: 1.12 DEC: 9 VEP: 0 Revision: 15
[    2.254657] amdgpu 0000:c3:00.0: MES: vmid_mask_mmhub 0x0000ff00, vmid_mask_gfxhub 0x0000ff00
[    2.254659] amdgpu 0000:c3:00.0: MES: gfx_hqd_mask 0x000000fe, compute_hqd_mask 0x0000000c, sdma_hqd_mask 0x000000fc
[    2.483644] amdgpu 0000:c3:00.0: RAS: optional ras ta ucode is not available
[    2.487044] amdgpu 0000:c3:00.0: RAP: optional rap ta ucode is not available
[    2.487052] amdgpu 0000:c3:00.0: SECUREDISPLAY: optional securedisplay ta ucode is not available
[    2.487091] amdgpu 0000:c3:00.0: smu driver if version = 0x0000002e, smu fw if version = 0x00000033, smu fw program = 0, smu fw version = 0x00664600 (102.70.0)
[    2.518021] amdgpu 0000:c3:00.0: SMU is initialized successfully!
[    2.519141] amdgpu 0000:c3:00.0: [drm] Display Core v3.2.369 initialized on DCN 4.0.1
[    2.519153] amdgpu 0000:c3:00.0: [drm] DP-HDMI FRL PCON supported
[    2.523461] amdgpu 0000:c3:00.0: [drm] DMUB hardware initialized: version=0x0A000800
[    2.887457] amdgpu 0000:c3:00.0: [drm] REG_WAIT timeout 1us * 150000 tries - optc401_disable_crtc line:235
[    2.892000] amdgpu 0000:c3:00.0: [drm] DP-1: PSR support 0, DC PSR ver -1, sink PSR ver 0 DPCD caps 0x0 su_y_granularity 0
[    2.944963] amdgpu 0000:c3:00.0: [drm] HDMI-A-1: PSR support 0, DC PSR ver -1, sink PSR ver 0 DPCD caps 0x0 su_y_granularity 0
[    2.945241] amdgpu 0000:c3:00.0: [drm] HDMI-A-2: PSR support 0, DC PSR ver -1, sink PSR ver 0 DPCD caps 0x0 su_y_granularity 0
[    2.946740] amdgpu 0000:c3:00.0: program CP_MES_CNTL : 0x4000000
[    2.946745] amdgpu 0000:c3:00.0: program CP_MES_CNTL : 0xc000000
[    2.955852] amdgpu: Virtual CRAT table created for GPU
[    2.955975] amdgpu: Topology: Add GPU node [0x1002:0x7590]
[    2.955995] amdgpu 0000:c3:00.0: SE 2, SH per SE 2, CU per SH 8, active_cu_number 32
[    2.956001] amdgpu 0000:c3:00.0: ring gfx_0.0.0 uses VM inv eng 0 on hub 0
[    2.956003] amdgpu 0000:c3:00.0: ring comp_1.0.0 uses VM inv eng 1 on hub 0
[    2.956004] amdgpu 0000:c3:00.0: ring comp_1.1.0 uses VM inv eng 4 on hub 0
[    2.956006] amdgpu 0000:c3:00.0: ring comp_1.0.1 uses VM inv eng 7 on hub 0
[    2.956007] amdgpu 0000:c3:00.0: ring comp_1.1.1 uses VM inv eng 8 on hub 0
[    2.956008] amdgpu 0000:c3:00.0: ring sdma0 uses VM inv eng 9 on hub 0
[    2.956009] amdgpu 0000:c3:00.0: ring sdma1 uses VM inv eng 10 on hub 0
[    2.956010] amdgpu 0000:c3:00.0: ring vcn_unified_0 uses VM inv eng 0 on hub 8
[    2.956012] amdgpu 0000:c3:00.0: ring jpeg_dec uses VM inv eng 1 on hub 8
[    2.989344] amdgpu: HMM registered 16304MB device memory
[    2.991050] amdgpu 0000:c3:00.0: Using BACO for runtime pm
[    2.992165] amdgpu 0000:c3:00.0: [drm] Registered 4 planes with drm panic
[    2.997517] [drm] Initialized amdgpu 3.64.0 for 0000:c3:00.0 on minor 1
[    3.014852] amdgpu 0000:c3:00.0: [drm] fb0: amdgpudrmfb frame buffer device
[    5.327888] amdgpu 0000:c3:00.0: [drm] REG_WAIT timeout 1us * 150000 tries - optc401_disable_crtc line:235
[    5.841975] snd_hda_intel 0000:c3:00.1: bound 0000:c3:00.0 (ops amdgpu_dm_audio_component_bind_ops [amdgpu])
[ 1145.721423] amdgpu 0000:c3:00.0: [drm] CRB Config Warning: DET size (10,16,0,0) + Compbuf size (1) >  CRB segments (21)
$ lspci | grep -i amd
c1:00.0 PCI bridge: Advanced Micro Devices, Inc. [AMD/ATI] Navi 10 XL Upstream Port of PCI Express Switch (rev 25)
c2:00.0 PCI bridge: Advanced Micro Devices, Inc. [AMD/ATI] Navi 10 XL Downstream Port of PCI Express Switch (rev 25)
c3:00.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Navi 44 [Radeon RX 9060 XT] (rev c0)
c3:00.1 Audio device: Advanced Micro Devices, Inc. [AMD/ATI] Navi 48 HDMI/DP Audio Controller
```

## Intel 8265NGW
Tested both wifi and bluetooth, both work well (when you get the antenna placement right 😆)
```
$ sudo dmesg | grep iwlwifi
[    5.336201] iwlwifi 0000:61:00.0: enabling device (0000 -> 0002)
[    5.337143] iwlwifi 0000:61:00.0: Detected crf-id 0xbadcafe, cnv-id 0x10 wfpm id 0x80000000
[    5.337152] iwlwifi 0000:61:00.0: PCI dev 24fd/1010, rev=0x230, rfid=0xd55555d5
[    5.337155] iwlwifi 0000:61:00.0: Detected Intel(R) Dual Band Wireless-AC 8265
[    5.388186] iwlwifi 0000:61:00.0: loaded firmware version 36.c8e8e144.0 8265-36.ucode op_mode iwlmvm
[    5.707351] iwlwifi 0000:61:00.0: base HW address: d4:6d:6d:03:a8:ef, OTP minor version: 0x4
[    5.805872] iwlwifi 0000:61:00.0 wlp97s0: renamed from wlan0
$ lspci | grep -i intel
61:00.0 Network controller: Intel Corporation Wireless 8265 / 8275 (rev 78)
```

## RTX 3070
I didn't know about this repo while testing but it worked with both nouveau/NVK and nvidia-open, I don't have any logs from this so I can remove the 3070 from the list if you want